### PR TITLE
OCP-936 filter by cost center

### DIFF
--- a/src/components/orders/list/OrderCostCenterFilter.tsx
+++ b/src/components/orders/list/OrderCostCenterFilter.tsx
@@ -1,0 +1,46 @@
+import {ChevronDownIcon} from "@chakra-ui/icons"
+import {Button, HStack, Menu, MenuButton, MenuItemOption, MenuList, MenuOptionGroup, Text, Tag} from "@chakra-ui/react"
+import {FC, useCallback, useEffect, useState} from "react"
+import {CostCenter, CostCenters} from "ordercloud-javascript-sdk"
+
+interface ICostCenterStatusFilter {
+  value: string
+  onChange: (newValue: any) => void
+}
+
+const OrderStatusFilter: FC<ICostCenterStatusFilter> = ({value = "", onChange}) => {
+  const [costCenters, setCostCenters] = useState<CostCenter[]>([])
+
+  const getCostCenters = useCallback(async () => {
+    const costCenters = await CostCenters.List("EducationBuyer")
+    setCostCenters(costCenters.Items)
+  }, [])
+
+  useEffect(() => {
+    getCostCenters()
+  }, [getCostCenters])
+
+  return (
+    <Menu>
+      <MenuButton as={Button} py={0} variant="outline" minW="auto">
+        <HStack alignContent="center" h="100%">
+          <Text>Cost Center</Text>
+          <Tag colorScheme="default">{costCenters.find((c) => c.ID === value)?.Name || "Any"}</Tag>
+          <ChevronDownIcon />
+        </HStack>
+      </MenuButton>
+      <MenuList>
+        <MenuOptionGroup defaultValue={value} title="Filter by Cost Center" type="radio" onChange={onChange}>
+          <MenuItemOption value="">Any</MenuItemOption>
+          {costCenters?.map((c) => (
+            <MenuItemOption key={c.ID} value={c.ID}>
+              {c.Name}
+            </MenuItemOption>
+          ))}
+        </MenuOptionGroup>
+      </MenuList>
+    </Menu>
+  )
+}
+
+export default OrderStatusFilter

--- a/src/components/orders/list/OrderList.tsx
+++ b/src/components/orders/list/OrderList.tsx
@@ -35,7 +35,8 @@ const OrderQueryMap = {
 const OrderFilterMap = {
   status: "Status",
   from: "from",
-  to: "to"
+  to: "to",
+  costcenter: "xp.CostCenter.ID"
 }
 
 const OrderDefaultServiceOptions = {parameters: ["Incoming"]}

--- a/src/components/orders/list/OrderListToolbar.tsx
+++ b/src/components/orders/list/OrderListToolbar.tsx
@@ -9,6 +9,7 @@ import OrderListActions from "./OrderListActions"
 import {OrderDirectionFilter} from "./OrderDirectionFilter"
 import ProtectedContent from "@/components/auth/ProtectedContent"
 import {appPermissions} from "config/app-permissions.config"
+import OrderCostCenterFilter from "./OrderCostCenterFilter"
 
 interface OrderListToolbarProps extends Omit<ListViewChildrenProps, "renderContent"> {
   onBulkEdit: () => void
@@ -60,6 +61,10 @@ const OrderListToolbar: FC<OrderListToolbarProps> = ({
 
               <OrderDirectionFilter value={routeParams["Direction"]} onChange={updateQuery("d", true)} />
               <OrderStatusFilter value={filterParams["Status"]} onChange={updateQuery("status", true)} />
+              <OrderCostCenterFilter
+                value={filterParams["xp.CostCenter.ID"]}
+                onChange={updateQuery("costcenter", true)}
+              />
               <OrderListActions />
             </Stack>
           </Stack>


### PR DESCRIPTION
- Hard coded `EducationBuyer` as buyerID parameter in list cost centers call
- Added CostCenterReader role to 'Product & Order Manager' security profile so that we could make the list cost centers call